### PR TITLE
Fixed error: "too few arguments to function ‘void dgetrs_..."

### DIFF
--- a/src/ODE_DLB/ODESolvers/seulex_LAPACK/seulex_LAPACK.H
+++ b/src/ODE_DLB/ODESolvers/seulex_LAPACK/seulex_LAPACK.H
@@ -55,8 +55,15 @@ SourceFiles
 #include "mkl_lapack.h"
 #else
 #include "lapacke.h"
+#if defined(LAPACK_dgetrs) && defined(LAPACK_dgetrf)
+#define dgetrs_(...) LAPACK_dgetrs (__VA_ARGS__)
+#define dgetrf_(...) LAPACK_dgetrf (__VA_ARGS__)
 #endif
+#endif
+
+#ifndef lapack_int
 #define lapack_int int
+#endif
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
 namespace Foam


### PR DESCRIPTION
Some of the recent interfaces of LAPACK libraries require that the length of the char* array should be passed as the last argument (size_t = 1). They usually provide the old interface by mangling names by dgetrs_ -> LAPACK_dgetrs, which is used in this fix