### PR TITLE
Fix tests to compile on latest development branch

### DIFF
--- a/src/thermophysicalModels/chemistryModel/chemistryModel/loadBalancedChemistryModel/loadBalancedChemistryModel.C
+++ b/src/thermophysicalModels/chemistryModel/chemistryModel/loadBalancedChemistryModel/loadBalancedChemistryModel.C
@@ -74,11 +74,11 @@ Foam::loadBalancedChemistryModel<ThermoType>::
             this->lookupOrDefault
             (
                 "begin",
-                unitNone,
+                units::none,
                 this->time().beginTime().value()
             )
         ),
-        repeat_(this->lookupOrDefault("repeat", unitNone, 0))
+        repeat_(this->lookupOrDefault("repeat", units::none, scalar(0)))
     {
         if(balancer_.log())
         {

--- a/tests/validation/pyjacTests/PSRTest/createBaseFields.H
+++ b/tests/validation/pyjacTests/PSRTest/createBaseFields.H
@@ -1,0 +1,56 @@
+// write base thermo fields - not registered since will be re-read by
+// thermo package
+
+Info<< "Creating base fields for time " << runTime.name() << endl;
+{
+    volScalarField Ydefault
+    (
+        IOobject
+        (
+            "Ydefault",
+            runTime.name(),
+            mesh,
+            IOobject::READ_IF_PRESENT,
+            IOobject::NO_WRITE,
+            false
+        ),
+        mesh,
+        dimensionedScalar(dimless, 1)
+    );
+
+    Ydefault.write();
+
+    volScalarField p
+    (
+        IOobject
+        (
+            "p",
+            runTime.name(),
+            mesh,
+            IOobject::READ_IF_PRESENT,
+            IOobject::NO_WRITE,
+            false
+        ),
+        mesh,
+        dimensionedScalar(dimPressure, p0)
+    );
+
+    p.write();
+
+    volScalarField T
+    (
+        IOobject
+        (
+            "T",
+            runTime.name(),
+            mesh,
+            IOobject::READ_IF_PRESENT,
+            IOobject::NO_WRITE,
+            false
+        ),
+        mesh,
+        dimensionedScalar(dimTemperature, T0)
+    );
+
+    T.write();
+}

--- a/tests/validation/pyjacTests/PSRTest/createFieldRefs.H
+++ b/tests/validation/pyjacTests/PSRTest/createFieldRefs.H
@@ -1,0 +1,4 @@
+basicChemistryModel& chemistry = pChemistry();
+scalar dtChem = min(chemistry.deltaTChem()[0], runTime.deltaT().value());
+PtrList<volScalarField>& Y = thermo.Y();
+volScalarField& p = thermo.p();

--- a/tests/validation/pyjacTests/PSRTest/testCase/constant/chemistryProperties
+++ b/tests/validation/pyjacTests/PSRTest/testCase/constant/chemistryProperties
@@ -1,13 +1,12 @@
 /*--------------------------------*- C++ -*----------------------------------*\
   =========                 |
-  \\      /  F ield         | DLBFoam: Dynamic Load Balancing
-   \\    /   O peration     | for fast reactive simulations
-    \\  /    A nd           |
-     \\/     M anipulation  | 2020, Aalto University, Finland
+  \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox
+   \\    /   O peration     | Website:  https://openfoam.org
+    \\  /    A nd           | Version:  dev
+     \\/     M anipulation  |
 \*---------------------------------------------------------------------------*/
 FoamFile
 {
-    version     2.0;
     format      ascii;
     class       dictionary;
     location    "constant";
@@ -23,7 +22,7 @@ chemistryType
 
 chemistry       on;
 
-initialChemicalTimeStep 1e30; // - should not influence ODE stability if all good.
+initialChemicalTimeStep 1e+30;
 
 odeCoeffs
 {
@@ -34,15 +33,24 @@ odeCoeffs
 
 loadbalancing
 {
-    log     false;
+    log             false;
 }
 
 refmapping
 {
-
 }
 
-// reactions dictionary is empty - {}
-#include "../../../pyjacTestMechanism/foam/reactions.foam"
+#include        "../../../pyjacTestMechanism/foam/reactions.foam"
+#includeEtc     "caseDicts/solvers/chemistry/TDAC/chemistryProperties.cfg"
+tabulation
+{
+    method          ISAT_pyJac;
+}
+
+reduction
+{
+    method          none;
+}
+
 
 // ************************************************************************* //

--- a/tests/validation/pyjacTests/PSRTest/testCase/constant/chemistryProperties
+++ b/tests/validation/pyjacTests/PSRTest/testCase/constant/chemistryProperties
@@ -1,12 +1,13 @@
 /*--------------------------------*- C++ -*----------------------------------*\
   =========                 |
-  \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox
-   \\    /   O peration     | Website:  https://openfoam.org
-    \\  /    A nd           | Version:  dev
-     \\/     M anipulation  |
+  \\      /  F ield         | DLBFoam: Dynamic Load Balancing
+   \\    /   O peration     | for fast reactive simulations
+    \\  /    A nd           |
+     \\/     M anipulation  | 2020, Aalto University, Finland
 \*---------------------------------------------------------------------------*/
 FoamFile
 {
+    version     2.0;
     format      ascii;
     class       dictionary;
     location    "constant";
@@ -22,7 +23,7 @@ chemistryType
 
 chemistry       on;
 
-initialChemicalTimeStep 1e+30;
+initialChemicalTimeStep 1e30; // - should not influence ODE stability if all good.
 
 odeCoeffs
 {
@@ -33,24 +34,15 @@ odeCoeffs
 
 loadbalancing
 {
-    log             false;
+    log     false;
 }
 
 refmapping
 {
+
 }
 
-#include        "../../../pyjacTestMechanism/foam/reactions.foam"
-#includeEtc     "caseDicts/solvers/chemistry/TDAC/chemistryProperties.cfg"
-tabulation
-{
-    method          ISAT_pyJac;
-}
-
-reduction
-{
-    method          none;
-}
-
+// reactions dictionary is empty - {}
+#include "../../../pyjacTestMechanism/foam/reactions.foam"
 
 // ************************************************************************* //

--- a/tests/validation/pyjacTests/PSRTest/testCase/constant/thermophysicalProperties
+++ b/tests/validation/pyjacTests/PSRTest/testCase/constant/thermophysicalProperties
@@ -1,13 +1,12 @@
 /*--------------------------------*- C++ -*----------------------------------*\
   =========                 |
-  \\      /  F ield         | DLBFoam: Dynamic Load Balancing
-   \\    /   O peration     | for fast reactive simulations
-    \\  /    A nd           |
-     \\/     M anipulation  | 2020, Aalto University, Finland
+  \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox
+   \\    /   O peration     | Website:  https://openfoam.org
+    \\  /    A nd           | Version:  dev
+     \\/     M anipulation  |
 \*---------------------------------------------------------------------------*/
 FoamFile
 {
-    version     2.0;
     format      ascii;
     class       dictionary;
     location    "constant";
@@ -19,16 +18,16 @@ thermoType
 {
     type            heRhoThermo;
     mixture         multicomponentMixture;
-    transport       sutherland;
+    transport       logPolynomial;
     thermo          janaf;
     energy          sensibleEnthalpy;
     equationOfState perfectGas;
     specie          specie;
 }
 
-defaultSpecie N2;
+defaultSpecie   N2;
 
-#include "../../../pyjacTestMechanism/foam/species.foam"
-#include "../../../pyjacTestMechanism/foam/thermo.foam"
+#include        "../../../pyjacTestMechanism/foam/species.foam"
+#include        "../../../pyjacTestMechanism/foam/thermo.foam"
 
 // ************************************************************************* //

--- a/tests/validation/pyjacTests/PSRTest/testCase/system/configDict
+++ b/tests/validation/pyjacTests/PSRTest/testCase/system/configDict
@@ -11,49 +11,14 @@ FoamFile
     format      ascii;
     class       dictionary;
     location    "system";
-    object      controlDict;
+    object      configDict;
 }
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
-application     PSRTest;
+DebugSwitches
+{
+    SolverPerformance   0;
+}
 
-startFrom       startTime;
-
-startTime       0;
-
-stopAt          endTime;
-
-endTime         0.07;
-
-deltaT          0.07;
-
-maxDeltaT       0.07;
-
-minDeltaT       1e-30;
-
-adjustTimeStep  off;
-
-writeControl    runTime;
-
-writeInterval   100;
-
-purgeWrite      0;
-
-writeFormat     binary;
-
-writeCompression off;
-
-timeFormat      general;
-
-timePrecision   12;
-
-runTimeModifiable no;
-
-libs
-(
-        "libchemistryModel_DLB.so"
-        "libODE_DLB.so"
-        "$FOAM_USER_LIBBIN/unittests/pyjacTestMech/build/libc_pyjac_test.so"
-);
 
 


### PR DESCRIPTION
Due to recent changes in the OpenFOAM-dev branch, PSRTest fails to compile on the latest development version.
The simplest way to resolve this issue is to copy the missing headers into PSRTest.